### PR TITLE
Add requirements and bump versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,7 @@ setup(
     classifiers=CLASSIFIERS,
     packages=find_packages(exclude=['example', 'docs']),
     include_package_data=True,
+    install_requires=[
+        'whoosh==2.7.4',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Development Status :: 4 - Beta',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = coverage-clean, py{27,34,35,36}-django{18,19,110,111,20}, coverage-report
-;envlist = py{36}-django{111}-win
+envlist = coverage-clean, py{34,35,36,37}-django{18,19,110,111,20,21,22}, coverage-report
 skipsdist = true
 
 [testenv]
@@ -19,24 +18,25 @@ whitelist_externals =
 platform=
 ;    linux: linux
 ;    win: win32
-    py27-django20: skip
 deps=
-    six==1.10.0
+    six==1.12.0
 ;    cssselect==0.9.2
 ;    pyquery==1.2.13
 ;    pygments==2.1.3
-    pytest==3.0.5
-    pytest-django==3.1.2
-    tox==2.3.1
-    coverage==4.2
+    pytest==5.0.1
+    pytest-django==3.5.1
+    tox==3.13.2
+    coverage==4.5.3
     backports.tempfile==1.0
     whoosh==2.7.4
 ;    django-sekizai==0.10
-    django18: Django~=1.8.14
-    django19: Django~=1.9.9
-    django110: Django~=1.10.4
-    django111: Django~=1.11.0
-    django20: Django~=2.0.03
+    django18: Django~=1.8.19
+    django19: Django~=1.9.13
+    django110: Django~=1.10.8
+    django111: Django~=1.11.22
+    django20: Django~=2.0.13
+    django21: Django~=2.1.10
+    django22: Django~=2.2.3
 
 
 [testenv:coverage-clean]


### PR DESCRIPTION
This closes #6 by adding Whoosh as a dependency of the package. It also bumps versions used in tox, removes explicitly stated Python 2.7 support and adds Python 3.7. 2.7 was removed as it is approaching EOL. The bumped versions of the testing suite aren't compatible with 2.7, so I thought it best to just remove support of it now.

Verified to work with Python 3.5 - 3.7 and Django 1.8 - 2.2. I can't install Python 3.4 with pyenv, so I'm only assuming it will work.

```
  coverage-clean: commands succeeded
ERROR:  py34-django18: InterpreterNotFound: python3.4
ERROR:  py34-django19: InterpreterNotFound: python3.4
ERROR:  py34-django110: InterpreterNotFound: python3.4
ERROR:  py34-django111: InterpreterNotFound: python3.4
ERROR:  py34-django20: InterpreterNotFound: python3.4
ERROR:  py34-django21: InterpreterNotFound: python3.4
ERROR:  py34-django22: InterpreterNotFound: python3.4
  py35-django18: commands succeeded
  py35-django19: commands succeeded
  py35-django110: commands succeeded
  py35-django111: commands succeeded
  py35-django20: commands succeeded
  py35-django21: commands succeeded
  py35-django22: commands succeeded
  py36-django18: commands succeeded
  py36-django19: commands succeeded
  py36-django110: commands succeeded
  py36-django111: commands succeeded
  py36-django20: commands succeeded
  py36-django21: commands succeeded
  py36-django22: commands succeeded
  py37-django18: commands succeeded
  py37-django19: commands succeeded
  py37-django110: commands succeeded
  py37-django111: commands succeeded
  py37-django20: commands succeeded
  py37-django21: commands succeeded
  py37-django22: commands succeeded
  coverage-report: commands succeeded
```